### PR TITLE
wip: add support for snappy compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,26 @@ ENV COMPOSER_ALLOW_SUPERUSER 1
 WORKDIR /tmp/
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        zlib1g-dev \
+		git \
+		libsnappy-dev \
         unzip \
+        zlib1g-dev \
 	&& rm -r /var/lib/apt/lists/* \
 	&& docker-php-ext-install -j$(nproc) zip \
 	&& curl -sS --fail https://getcomposer.org/installer | php \
 	&& mv /tmp/composer.phar /usr/local/bin/composer 
 
+
+RUN git clone --recursive https://github.com/kjdev/php-ext-snappy.git \
+	&& cd php-ext-snappy \
+	&& git checkout tags/0.1.9 \
+	&& phpize \
+	&& ./configure \
+	&& make \
+	&& make install
+
 COPY . /code/
+COPY /docker/php.ini /usr/local/etc/php/php.ini
 WORKDIR /code/
 RUN composer install --no-interaction
 CMD ["php", "/code/main.php"]

--- a/docker/php.ini
+++ b/docker/php.ini
@@ -1,0 +1,9 @@
+; Maximum amount of memory a script may consume (128MB)
+; http://php.net/memory-limit
+memory_limit = -1
+
+; Defines the default timezone used by the date functions
+; http://php.net/date.timezone
+date.timezone = UTC
+
+extension=snappy.so


### PR DESCRIPTION
```
<?php

$contents = file_get_contents("/data/composer.lock");
$dec = snappy_compress($contents);
file_put_contents("/data/composer.lock.snappy", $dec);


$contents = file_get_contents("/data/composer.lock.snappy");
$dec = snappy_uncompress($contents);
file_put_contents("/data/composer.lock.dec", $dec);

```
